### PR TITLE
Update GFlashText.as

### DIFF
--- a/source/com/genome2d/components/renderables/flash/GFlashText.as
+++ b/source/com/genome2d/components/renderables/flash/GFlashText.as
@@ -22,7 +22,7 @@ package com.genome2d.components.renderables.flash
 		
 		public function set textFormat(p_textFormat:TextFormat):void {
 			__tfTextField.defaultTextFormat = p_textFormat;
-			if (__tfTextField.text.length > 0) __tfTextField.setTextFormat(p_textFormat, 0, __tfTextField.text.length-1);
+			if (__tfTextField.text.length > 0) __tfTextField.setTextFormat(p_textFormat, 0, __tfTextField.text.length);
 			
 			_bInvalidate = true;
 		}


### PR DESCRIPTION
there is no need of "-1", just test your code with this:

textField.text = "a";
        if(textField.text.length > 0){
            textField.setTextFormat(new TextFormat(), 0, textField.length - 1);
        }
        textField.text = "_";

you'll get RTE:

[Fault] exception, information=RangeError: Error #2006: The supplied index is out of bounds.
at flash.text::TextField/setTextFormat()
